### PR TITLE
style: .eslintrc.json에 대한 prettier 포맷터 활성화

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ module.exports = {
     "prettier",
   ],
   ignorePatterns: [
-    ".eslintrc.json",
     ".yarn/*",
     ".next/*",
     "jest.config.js",


### PR DESCRIPTION
.eslintrc.json에 대한 ignore 구분을 제거함으로
eslint에서의 prettier 포맷터가 해당 json 파일에서 동작하도록 변경합니다.